### PR TITLE
made changes to reduce # of housing objects created

### DIFF
--- a/src/main/java/edu/texas/social/computing/housing/AgentOrdering.java
+++ b/src/main/java/edu/texas/social/computing/housing/AgentOrdering.java
@@ -3,11 +3,13 @@ package edu.texas.social.computing.housing;
 import edu.texas.social.computing.housing.initialization.NoOwnersInitialization;
 import edu.texas.social.computing.housing.matching.PoorestAgentWinsMatching;
 import edu.texas.social.computing.housing.objects.Agent;
-import edu.texas.social.computing.housing.objects.House;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created by tiffanytillett on 11/25/18.
@@ -34,6 +36,25 @@ public class AgentOrdering {
         int n = ParseFileForN(filename);
 
         Housing housing = new FairHousing(filename, new NoOwnersInitialization(), new PoorestAgentWinsMatching(), null);
+        if(housing == null) return orderings;
+
+        Set<Agent> J = new HashSet<>();
+        for (int j = 0; j < n; j++) {
+            J.add(housing.agents.get(j));
+        }
+
+        orderings = GenOrderings(J);
+
+        return orderings;
+    }
+
+    public static List<List<Agent>> GenOrderings(Housing housing) {
+
+        List<List<Agent>> orderings = null;
+        //int n = ParseFileForN(filename);
+        int n = housing.agents.size();
+
+        //Housing housing = new FairHousing(filename, new NoOwnersInitialization(), new PoorestAgentWinsMatching(), null);
         if(housing == null) return orderings;
 
         Set<Agent> J = new HashSet<>();

--- a/src/main/java/edu/texas/social/computing/housing/Assignment.java
+++ b/src/main/java/edu/texas/social/computing/housing/Assignment.java
@@ -46,13 +46,17 @@ public class Assignment
         {
 
             allocations = new HashSet<>();
-            List<List<Agent>> agentPriorities = AgentOrdering.GenOrderings(filename);
+            housing = new FairHousing(filename, new NoOwnersInitialization(), new DefaultMatching(), null);
+            List<List<Agent>> agentPriorities = AgentOrdering.GenOrderings(housing);
+            Map<House, Agent> owners;
             // Loop through the list of all agent priority lists and solve the housing allocation problem given each one
             for (List<Agent> agentPrior: agentPriorities) {
                 System.out.println(agentPrior.toString());
 
-                housing = new FairHousing(filename, new NoOwnersInitialization(), new DefaultMatching(), agentPrior);
-                Map<House, Agent> owners = housing.solve();
+                //housing = new FairHousing(filename, new NoOwnersInitialization(), new DefaultMatching(), agentPrior);
+                housing.initialize();
+                housing.setAgentPriority(agentPrior);
+                owners = housing.solve();
 
                 // Add the allocation to the list of allocations
                 Allocation allocation = new Allocation(owners);

--- a/src/main/java/edu/texas/social/computing/housing/Housing.java
+++ b/src/main/java/edu/texas/social/computing/housing/Housing.java
@@ -42,6 +42,10 @@ public abstract class Housing {
        return this.matchingStrategy.findMatching(agents, owners, houses, agentPriority);
     }
 
+    public void setAgentPriority(List<Agent> agentPriority) {
+        this.agentPriority = agentPriority;
+    }
+
     private int ParseFile(String filename) {
 
         int n = 0;

--- a/src/main/java/edu/texas/social/computing/housing/objects/Allocation.java
+++ b/src/main/java/edu/texas/social/computing/housing/objects/Allocation.java
@@ -46,6 +46,14 @@ public class Allocation {
 		return house2AgentMap.equals(mapping);
 	}
 
+	@Override
+	public int hashCode()
+	{
+		return house2AgentMap.hashCode();
+	}
+
+
+
 	public int getFairnessScore()
 	{
 		int fairness = 0;


### PR DESCRIPTION
added hashCode method to allocation to properly utilize the hashSet for the allocations object
made modifications to allow the creation of a single housing object (housing object now has capability to reset the priority, genOrderings now takes in a housing instead of a filename, assignment now resets the owners and the agent priority instead of creating a new object)